### PR TITLE
Add integration test for bidirectional friendship relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ To get a local copy up and running follow these simple example steps.
 
 ### Prerequisites
 
-ruby '2.7.2'
-Rails: 5.2.3
-Postgres: >=9.5
+ruby 2.7.2
+Rails: >= 5.2.4
+Postgres: >= 9.5
 
 ### Setup
 
-Instal gems with:
+Install gems with:
 
 ```
 bundle install

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,6 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :friendships
   has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id'
-  scope :current_user_friends, -> { where('user_id == ?', current_user.id) }
 
   def friends
     friends_array = friendships.map { |friendship| friendship.friend if friendship.confirmed }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,4 +22,33 @@ RSpec.describe User, type: :model do
     user = User.new(name: 'name', email: 'email@testing.com', password: nil)
     expect(user).to_not be_valid
   end
+
+  it 'includes friend on .friends user bidirectional helper method' do
+    user = User.create(id: 1, name: 'name', email: 'email@testing.com', password: 'password')
+    friend = User.create(id: 2, name: 'name', email: 'friend_email@testing.com', password: 'password')
+    Friendship.create(user_id: user.id, friend_id: friend.id, confirmed: true)
+    expect(user.friends).to include(friend)
+  end
+
+  it 'includes user on .friend friend bidirectional helper method' do
+    user = User.create(id: 1, name: 'name', email: 'email@testing.com', password: 'password')
+    friend = User.create(id: 2, name: 'name', email: 'friend_email@testing.com', password: 'password')
+    Friendship.create(user_id: friend.id, friend_id: user.id, confirmed: true)
+    expect(friend.friends).to include(user)
+  end
+
+  it 'expects friend?(friend) to return true' do
+    user = User.create(id: 1, name: 'name', email: 'email@testing.com', password: 'password')
+    friend = User.create(id: 2, name: 'name', email: 'friend_email@testing.com', password: 'password')
+    Friendship.create(user_id: user.id, friend_id: friend.id, confirmed: true)
+    expect(user.friend?(friend)).to be(true)
+  end
+
+  it 'has many inverse friendships' do
+    should respond_to(:inverse_friendships)
+  end
+
+  it 'has many friendships' do
+    should respond_to(:friendships)
+  end
 end


### PR DESCRIPTION
Milestone 6: Friendships v2: 

Based on https://explainextended.com/2009/03/07/selecting-friends/ biderectional friendship model was updated and created just asking for actual user and friend id.

On this milestone we:

- Designed user and friendship models to store records on database.
- Create has_many :inverse_friendships relation based on the friend id of the friendship table in order to implement bidirectional friendship with just 2 rows.
- Created unit testing for friends method, include method, and has_many :inverse_friendships relation, with respond_to rspec matcher.